### PR TITLE
Fix: Update social media links in website footer

### DIFF
--- a/src/Components/FooterView.vue
+++ b/src/Components/FooterView.vue
@@ -26,10 +26,8 @@ const footerData = reactive({
   ],
   
   socialMedia: [
-    { platform: 'Facebook', icon: 'pi-facebook', url: '#' },
-    { platform: 'Twitter', icon: 'pi-twitter', url: '#' },
-    { platform: 'Instagram', icon: 'pi-instagram', url: '#' },
-    { platform: 'LinkedIn', icon: 'pi-linkedin', url: '#' },
+    { platform: 'Instagram', icon: 'pi-instagram', url: 'https://www.instagram.com/umatt_team/' },
+    { platform: 'LinkedIn', icon: 'pi-linkedin', url: 'https://www.linkedin.com/in/university-of-manitoba-association-of-tiny-tractor-umatt/' },
   ],
   
   copyright: {


### PR DESCRIPTION
Social medial links have been added for team's Instagram and LinkedIn pages. References to Facebook and Twitter have been removed as the team no longer manages their Facebook page and does not have a Twitter account.

Fixes #14 