### PR TITLE
Removed established date from team photo

### DIFF
--- a/src/Components/AboutSection.vue
+++ b/src/Components/AboutSection.vue
@@ -27,11 +27,12 @@
                 alt="UMATT team working on their quarter-scale tractor"
                 class="about-image"
               />
-              <div class="image-overlay">
+              <!-- following div is for established / competition data (to be updated in future) -->
+              <!-- <div class="image-overlay">
                 <div class="image-badge">
                   <span class="badge-text">Est. 2010</span>
                 </div>
-              </div>
+              </div> -->
             </div>
             <div class="image-accent top-right"></div>
             <div class="image-accent bottom-left"></div>


### PR DESCRIPTION
Removed established date (i.e., Est. 2010) from team photo on the website. Commented out the code block responsible for that with a comment about its purpose so that they can easily be updated later in the future.

Fixes #19 