### PR TITLE
Animated underline in Achievements section removed on website

### DIFF
--- a/src/Components/AchievementsSection.vue
+++ b/src/Components/AchievementsSection.vue
@@ -291,26 +291,12 @@ onUnmounted(() => {
   position: relative;
 }
 
-/* Animated underline */
 .heading-underline {
   width: 80px;
   height: 4px;
-  background: linear-gradient(90deg, #F2A900, #FFD166);
+  background-color: var(--umatt-c-gold);
   border-radius: 2px;
   margin: 0.75rem auto 1.5rem;
-  position: relative;
-  overflow: hidden;
-}
-
-.heading-underline::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
-  animation: shimmer 2s infinite;
 }
 
 @keyframes shimmer {


### PR DESCRIPTION
The animated underline in the Achievements section, below "Our Achievements & Impact" heading, has been removed to maintain consistency with other section headings.

Fixes #26 